### PR TITLE
feat: cumulative analytics aggregates + Convex-native site stats

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import MainMenu from "./components/MainMenu";
 import TeamSelection from "./components/TeamSelection";
 import About from "./pages/About";
 import Feedback from "./pages/Feedback";
+import PageviewTracker from "./components/PageviewTracker";
 import { preloadPlayers } from "./lib/nba2kapi";
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
     <Router>
       <div className="App background flex flex-col overflow-auto h-screen">
         <Navigation />
+        <PageviewTracker />
         <Routes>
           <>
             <Route exact path="/" element={<MainMenu />} />

--- a/src/components/PageviewTracker.jsx
+++ b/src/components/PageviewTracker.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { useMutation } from "convex/react";
+import { api } from "../convex/_generated/api";
+import { getVisitorId } from "../utils/visitorId";
+
+/**
+ * Fires a Convex `recordPageview` on each route change. Fire-and-forget.
+ * A ref guards against StrictMode double-renders inflating counts.
+ * Renders nothing.
+ */
+export default function PageviewTracker() {
+  const location = useLocation();
+  const recordPageview = useMutation(api.siteStats.recordPageview);
+  const lastPath = useRef(null);
+
+  useEffect(() => {
+    const path = location.pathname;
+    if (lastPath.current === path) return;
+    lastPath.current = path;
+    try {
+      const p = recordPageview({ path, visitorId: getVisitorId() });
+      if (p && typeof p.catch === "function") p.catch(() => {});
+    } catch {
+      /* never break the app over analytics */
+    }
+  }, [location.pathname, recordPageview]);
+
+  return null;
+}

--- a/src/convex/_generated/api.d.ts
+++ b/src/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as analytics from "../analytics.js";
 import type * as crons from "../crons.js";
 import type * as feedback from "../feedback.js";
+import type * as siteStats from "../siteStats.js";
 
 import type {
   ApiFromModules,
@@ -22,6 +23,7 @@ declare const fullApi: ApiFromModules<{
   analytics: typeof analytics;
   crons: typeof crons;
   feedback: typeof feedback;
+  siteStats: typeof siteStats;
 }>;
 
 /**

--- a/src/convex/analytics.ts
+++ b/src/convex/analytics.ts
@@ -21,6 +21,18 @@ export const trackEvent = mutation({
       timestamp: Date.now(),
       metadata,
     });
+
+    // Also maintain a cumulative aggregate per eventType so lifetime totals
+    // survive the 90-day cleanup cron (raw events = rolling detail).
+    const existing = await ctx.db
+      .query("analyticsAggregates")
+      .withIndex("by_type", (q) => q.eq("eventType", eventType))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { count: existing.count + 1, lastUpdated: Date.now() });
+    } else {
+      await ctx.db.insert("analyticsAggregates", { eventType, count: 1, lastUpdated: Date.now() });
+    }
   },
 });
 
@@ -117,5 +129,39 @@ export const cleanupOldEvents = internalMutation({
     if (deleted > 0) {
       console.log(`[analytics] Cleaned up ${deleted} events older than ${retentionDays} days`);
     }
+  },
+});
+
+/**
+ * Get all cumulative aggregate counts (lifetime, survives the cleanup cron).
+ */
+export const getAllAggregates = query({
+  args: {},
+  handler: async (ctx) => {
+    const aggs = await ctx.db.query("analyticsAggregates").collect();
+    const result: Record<string, number> = {};
+    for (const a of aggs) result[a.eventType] = a.count;
+    return result;
+  },
+});
+
+/**
+ * Internal: set an aggregate count directly. Used for the one-time backfill/seed
+ * to an honest lifetime floor (max of current 90-day count and the documented
+ * baseline) so totals grow accurately from there.
+ */
+export const setAggregateCount = internalMutation({
+  args: { eventType: v.string(), count: v.number() },
+  handler: async (ctx, { eventType, count }) => {
+    const existing = await ctx.db
+      .query("analyticsAggregates")
+      .withIndex("by_type", (q) => q.eq("eventType", eventType))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { count, lastUpdated: Date.now() });
+    } else {
+      await ctx.db.insert("analyticsAggregates", { eventType, count, lastUpdated: Date.now() });
+    }
+    return { eventType, count };
   },
 });

--- a/src/convex/crons.ts
+++ b/src/convex/crons.ts
@@ -10,4 +10,10 @@ crons.daily(
   { retentionDays: 90 }
 );
 
+crons.daily(
+  "prune-pageview-visits",
+  { hourUTC: 4, minuteUTC: 30 },
+  internal.siteStats.pruneVisits
+);
+
 export default crons;

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -18,14 +18,33 @@ export default defineSchema({
   analyticsEvents: defineTable({
     eventType: v.string(),
     timestamp: v.number(),
-    metadata: v.optional(v.object({
-      gameSize: v.optional(v.string()),      // "1v1", "2v2", etc.
-      queryParams: v.optional(v.string()),   // JSON of filters used
-      roundNumber: v.optional(v.number()),
-      totalRounds: v.optional(v.number()),
-    })),
+    // Loosely typed: tolerate legacy/ad-hoc fields on old events so the schema
+    // deploys cleanly against existing data. Current code writes structured
+    // metadata (gameSize / queryParams / roundNumber / totalRounds).
+    metadata: v.optional(v.any()),
   })
     .index("by_type", ["eventType"])
     .index("by_timestamp", ["timestamp"])
     .index("by_type_and_timestamp", ["eventType", "timestamp"]),
+
+  // Cumulative per-eventType counts so lifetime totals survive the 90-day
+  // cleanup cron (raw analyticsEvents are pruned; these are not).
+  analyticsAggregates: defineTable({
+    eventType: v.string(),
+    count: v.number(),
+    lastUpdated: v.number(),
+  }).index("by_type", ["eventType"]),
+
+  // --- Site stats (pageview analytics) ---
+  // Cumulative counters keyed by "total" | "path:<p>" | "day:<YYYY-MM-DD>" | "uvday:<YYYY-MM-DD>".
+  pageviewCounters: defineTable({
+    key: v.string(),
+    count: v.number(),
+  }).index("by_key", ["key"]),
+
+  // Per-day unique-visitor dedup rows (pruned > 120 days by cron).
+  pageviewVisits: defineTable({
+    date: v.string(),
+    visitorId: v.string(),
+  }).index("by_date_and_visitor", ["date", "visitorId"]),
 });

--- a/src/convex/siteStats.ts
+++ b/src/convex/siteStats.ts
@@ -1,0 +1,134 @@
+import { mutation, internalQuery, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const dstr = (ms: number) => new Date(ms).toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+
+function sanitizePath(raw: string): string | null {
+  let p = (raw || "").split("?")[0].split("#")[0].trim();
+  if (!p.startsWith("/")) return null;
+  if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+  if (p.length > 120) p = p.slice(0, 120);
+  return p;
+}
+
+/**
+ * Public: record a pageview. Call fire-and-forget from the client.
+ * Increments cumulative counters (total / per-path / per-day) and dedupes
+ * unique visitors per day.
+ */
+export const recordPageview = mutation({
+  args: { path: v.string(), visitorId: v.string() },
+  handler: async (ctx, { path, visitorId }) => {
+    const p = sanitizePath(path);
+    if (!p) return;
+    const vId = (visitorId || "anon").slice(0, 64);
+    const date = dstr(Date.now());
+
+    const bump = async (key: string) => {
+      const existing = await ctx.db
+        .query("pageviewCounters")
+        .withIndex("by_key", (q) => q.eq("key", key))
+        .first();
+      if (existing) await ctx.db.patch(existing._id, { count: existing.count + 1 });
+      else await ctx.db.insert("pageviewCounters", { key, count: 1 });
+    };
+
+    await bump("total");
+    await bump(`path:${p}`);
+    await bump(`day:${date}`);
+
+    const seen = await ctx.db
+      .query("pageviewVisits")
+      .withIndex("by_date_and_visitor", (q) => q.eq("date", date).eq("visitorId", vId))
+      .first();
+    if (!seen) {
+      await ctx.db.insert("pageviewVisits", { date, visitorId: vId });
+      await bump(`uvday:${date}`);
+    }
+  },
+});
+
+/**
+ * Internal: one-call dashboard of traffic + actions + feedback.
+ * Run via `npx convex run siteStats:getDashboard --prod`.
+ */
+export const getDashboard = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const counters = await ctx.db.query("pageviewCounters").collect();
+    const map: Record<string, number> = {};
+    for (const c of counters) map[c.key] = c.count;
+
+    const days: { date: string; views: number; uniques: number }[] = [];
+    for (const c of counters) {
+      if (c.key.startsWith("day:")) {
+        const date = c.key.slice(4);
+        days.push({ date, views: c.count, uniques: map[`uvday:${date}`] ?? 0 });
+      }
+    }
+    days.sort((a, b) => (a.date < b.date ? 1 : -1)); // newest first
+
+    const now = Date.now();
+    const cutoff7 = dstr(now - 7 * DAY_MS);
+    const cutoff30 = dstr(now - 30 * DAY_MS);
+    const sum = (cutoff: string, field: "views" | "uniques") =>
+      days.filter((d) => d.date >= cutoff).reduce((s, d) => s + d[field], 0);
+
+    const topPages = counters
+      .filter((c) => c.key.startsWith("path:"))
+      .map((c) => ({ path: c.key.slice(5), views: c.count }))
+      .sort((a, b) => b.views - a.views)
+      .slice(0, 15);
+
+    const aggs = await ctx.db.query("analyticsAggregates").collect();
+    const actions: Record<string, number> = {};
+    for (const a of aggs) actions[a.eventType] = a.count;
+
+    const feedback = await ctx.db.query("feedback").collect();
+    const byStatus: Record<string, number> = {};
+    for (const f of feedback) byStatus[f.status] = (byStatus[f.status] ?? 0) + 1;
+    const recent = feedback
+      .slice()
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 8)
+      .map((f) => ({
+        title: f.title,
+        type: f.type,
+        status: f.status,
+        upvotes: f.upvotes,
+        createdAt: f.createdAt,
+      }));
+
+    return {
+      pageviews: {
+        total: map["total"] ?? 0,
+        last7: sum(cutoff7, "views"),
+        last30: sum(cutoff30, "views"),
+        byDay: days.slice(0, 30),
+      },
+      uniques: { last7: sum(cutoff7, "uniques"), last30: sum(cutoff30, "uniques") },
+      topPages,
+      actions,
+      feedback: { total: feedback.length, byStatus, recent },
+    };
+  },
+});
+
+/** Internal: prune the per-day unique-visitor dedup rows older than 120 days (cron). */
+export const pruneVisits = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = dstr(Date.now() - 120 * DAY_MS);
+    const old = await ctx.db
+      .query("pageviewVisits")
+      .withIndex("by_date_and_visitor", (q) => q.lt("date", cutoff))
+      .take(4000);
+    let deleted = 0;
+    for (const row of old) {
+      await ctx.db.delete(row._id);
+      deleted++;
+    }
+    return { deleted, more: old.length === 4000 };
+  },
+});

--- a/src/utils/visitorId.js
+++ b/src/utils/visitorId.js
@@ -1,0 +1,19 @@
+// Persistent anonymous visitor id, shared by feedback + analytics so a
+// "visitor" is consistent across both. Key matches the original inline
+// helper in pages/Feedback.jsx.
+const KEY = "blacktop-blitz-visitor-id";
+
+export function getVisitorId() {
+  try {
+    let id = localStorage.getItem(KEY);
+    if (!id) {
+      id =
+        (typeof crypto !== "undefined" && crypto.randomUUID && crypto.randomUUID()) ||
+        `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      localStorage.setItem(KEY, id);
+    }
+    return id;
+  } catch {
+    return "anon";
+  }
+}


### PR DESCRIPTION
## Why
Blacktop's daily cleanup cron prunes `analyticsEvents` to 90 days **with no cumulative backstop** — so lifetime totals (e.g. "teams generated") were being silently deleted every night. This adds a cumulative aggregate (the urgent fix) plus the same pullable analytics layer as aux-wars.

## Changes
- **`analyticsAggregates` table** + the public `trackEvent` now also upserts it, so lifetime counts survive the cleanup cron. Added `getAllAggregates` + internal `setAggregateCount`.
- **`siteStats.ts`**: `recordPageview` (public), `getDashboard` (internal — traffic + aggregates + feedback), `pruneVisits` (daily cron).
- **`pageviewCounters` + `pageviewVisits` tables**; `PageviewTracker` mounted in `App.jsx`; shared `getVisitorId()` util (same localStorage id as feedback).
- Loosened `analyticsEvents.metadata` to `v.any()` to tolerate legacy ad-hoc fields (required for a clean deploy).

## Verified (on dev)
- `trackEvent` increments the aggregate (`draft_completed` 0→2 over two calls)
- `setAggregateCount` seed works (`query_executed` → 6210)
- pageview dedup + `getDashboard` correct; client `npm run build` green

## Post-deploy steps (Wilson runs prod deploy; I run the seed)
After `convex deploy --prod`, seed aggregates to honest floors = max(current 90-day, Feb baseline):
```
npx convex run analytics:setAggregateCount '{"eventType":"query_executed","count":6210}' --prod
npx convex run analytics:setAggregateCount '{"eventType":"draft_completed","count":3105}' --prod
# (draft_started / player_selected / draft_abandoned / game_reset → current 90-day from getEventCounts)
```
Then pull anytime: `npx convex run siteStats:getDashboard --prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)