### PR TITLE
docs: rewrite ROADMAP to match reality + current usage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,173 +1,48 @@
-# Blacktop Blitz - Project Roadmap
+# Blacktop Blitz — Roadmap
 
-## 🎯 Vision
-Transform Blacktop Blitz from a simple team generator into an immersive, social basketball draft experience that captures the excitement of playground basketball culture.
+> Rewritten June 2026. The previous version described a Next.js 14 + Supabase
+> rewrite that was never built; this reflects what actually ships today.
 
-## 🏀 Core Goals
-1. **Immersive Experience**: Create a visually stunning, basketball court-themed UI with 3D effects and sound
-2. **Social Gaming**: Enable real-time multiplayer drafts and community features
-3. **Data Rich**: Enhance player data with images, stats, and dynamic content
-4. **Performance**: Build a fast, responsive PWA that works offline
-5. **Engagement**: Add progression systems, challenges, and competitive elements
+## What it is
+A fast NBA 2K Blacktop team randomizer/draft tool. Pick a game size and filters,
+draft teams, compare them. Live at https://blacktopblitz.com.
 
-## 🏗️ Technical Architecture
+## Actual architecture (June 2026)
+- **Frontend:** React 19 + Vite, React Router, MUI, Framer Motion
+- **Backend:** Convex (feedback, analytics events, site stats)
+- **Player data:** static `public/players.json`, refreshed daily by
+  `.github/workflows/sync-players.yml` from the [nba2kapi](https://github.com/woverfield/nba2kapi)
+  `/api/players/bulk` endpoint — no API calls from end-user browsers
+- **Hosting:** Vercel · **Analytics:** Vercel Analytics + custom Convex events
 
-### Frontend Stack
-- **Framework**: Next.js 14 (App Router)
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS + Custom CSS
-- **Animations**: Framer Motion + Three.js
-- **State**: Zustand
-- **Data Fetching**: TanStack Query
-- **Sound**: Howler.js
+## Usage (Convex prod, June 2026)
+| Metric | Value |
+|--------|-------|
+| Teams generated (`query_executed`) | 6,862 |
+| Drafts started | 2,955 |
+| Drafts completed | 3,315 |
+| Players selected | 4,393 |
+| Pageviews (30d) | 799 (305 uniques) |
 
-### Backend Stack
-- **Database**: Supabase (PostgreSQL)
-- **Auth**: Supabase Auth
-- **Real-time**: Supabase Realtime
-- **Storage**: Supabase Storage
-- **Edge Functions**: Supabase Functions
+Feb 2026 baseline was 6,210 teams / 3,105 drafts completed — steady growth.
 
-### Infrastructure
-- **Hosting**: Vercel
-- **CDN**: Vercel Edge Network
-- **Analytics**: Vercel Analytics + Custom Events
-- **Monitoring**: Sentry
+## Health notes
+- Player data is only as fresh as nba2kapi upstream. The daily sync "succeeds"
+  even when upstream is stale, so freshness depends on the nba2kapi scraper
+  staying healthy (fixed June 2026 — see that repo).
+- `.env.local` references only the **dev** Convex deployment
+  (`dapper-marmot-81`); the live site runs on a separate **prod** deployment.
 
-## 📋 Implementation Phases
+## Possible next steps (not committed)
+- **Shareable drafts** — permalink a generated matchup (high-leverage, cheap)
+- **Filter presets / "surprise me"** — reduce friction on the main loop
+- **Funnel polish** — `draft_abandoned` (967) vs completed (3,315): investigate
+  where the ~25% who start but don't finish drop off
+- **Roster freshness banner** — show "data as of <date>" from players.json
+- **PWA / install** — it's already a single-purpose tool people reopen
 
-### Phase 1: Foundation (Weeks 1-2)
-- [x] Document project roadmap and specifications
-- [ ] Set up Next.js 14 with TypeScript
-- [ ] Configure Supabase project
-- [ ] Design and implement database schema
-- [ ] Set up authentication system
-- [ ] Create base component library
-- [ ] Migrate existing player data
-
-### Phase 2: Core Features (Weeks 3-4)
-- [ ] Build new player card components with animations
-- [ ] Implement real-time draft system
-- [ ] Add player image scraping and caching
-- [ ] Create draft history tracking
-- [ ] Build team management features
-- [ ] Implement search and filtering
-
-### Phase 3: Creative UI/UX (Weeks 5-6)
-- [ ] Design and implement basketball court UI
-- [ ] Add 3D card effects and animations
-- [ ] Implement sound design system
-- [ ] Create day/night themes
-- [ ] Add particle effects and celebrations
-- [ ] Build smooth transitions
-
-### Phase 4: Social Features (Weeks 7-8)
-- [ ] Implement multiplayer draft rooms
-- [ ] Build leaderboard system
-- [ ] Create challenge system
-- [ ] Add social sharing features
-- [ ] Implement user profiles
-- [ ] Build notification system
-
-### Phase 5: Advanced Features (Weeks 9-10)
-- [ ] Create "MyPark" customization
-- [ ] Add AI draft analysis
-- [ ] Implement tournament brackets
-- [ ] Build statistics dashboard
-- [ ] Add achievement system
-- [ ] Create draft replay viewer
-
-### Phase 6: Polish & Launch (Weeks 11-12)
-- [ ] Performance optimization
-- [ ] PWA implementation
-- [ ] Comprehensive testing
-- [ ] Documentation
-- [ ] Marketing site
-- [ ] Launch preparation
-
-## 🎯 Success Metrics
-
-### User Engagement
-- Daily Active Users (DAU)
-- Average session duration
-- Drafts completed per user
-- Return user rate
-
-### Technical Performance
-- Lighthouse score > 95
-- First Contentful Paint < 1s
-- Time to Interactive < 2s
-- Zero downtime deployments
-
-### Feature Adoption
-- Multiplayer draft participation
-- Social features usage
-- Challenge completion rates
-- Team saves and shares
-
-## 🚀 Key Features
-
-### Must Have (MVP)
-- User authentication
-- Enhanced player cards with images
-- Real-time drafting
-- Team saving/sharing
-- Basic sound effects
-- Mobile responsive
-
-### Should Have
-- Multiplayer drafts
-- Leaderboards
-- Player search/filter
-- Draft history
-- PWA features
-- Advanced animations
-
-### Nice to Have
-- MyPark customization
-- AI analysis
-- Tournament mode
-- Achievement system
-- Draft replay
-- Voice chat
-
-## 🎨 Design Principles
-
-1. **Basketball First**: Every design decision should reinforce the basketball theme
-2. **Smooth & Responsive**: Animations should be fluid and never block user actions
-3. **Accessible**: Ensure usability for all users, including keyboard navigation
-4. **Performant**: Optimize for mobile devices and slow connections
-5. **Delightful**: Add surprise and delight through micro-interactions
-
-## 📊 Risk Mitigation
-
-### Technical Risks
-- **Data Scraping**: Build robust error handling and fallbacks
-- **Real-time Sync**: Implement conflict resolution and offline support
-- **Performance**: Progressive enhancement and lazy loading
-
-### User Experience Risks
-- **Complexity**: Provide onboarding and tutorials
-- **Mobile**: Test extensively on various devices
-- **Sound**: Make audio optional with clear controls
-
-## 🔄 Development Workflow
-
-1. **Feature Branch**: Create feature branches from main
-2. **Testing**: Write tests for critical paths
-3. **Review**: Code review before merging
-4. **Deploy**: Automatic deployments to preview
-5. **Monitor**: Track metrics and errors
-
-## 📝 Next Steps
-
-1. Create detailed technical specifications
-2. Set up development environment
-3. Begin Phase 1 implementation
-4. Set up project management tools
-5. Schedule regular progress reviews
-
----
-
-*Last Updated: 2025-08-15*
-*Version: 1.0*
+## Design principles
+1. Basketball-first, playground energy
+2. Fast — the core loop is generate → draft → compare; keep it instant
+3. Mobile-first; most traffic is `/` and `/qplay`
+4. Delightful micro-interactions, never blocking

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ A fast NBA 2K Blacktop team randomizer/draft tool. Pick a game size and filters,
 draft teams, compare them. Live at https://blacktopblitz.com.
 
 ## Actual architecture (June 2026)
-- **Frontend:** React 19 + Vite, React Router, MUI, Framer Motion
+- **Frontend:** React 18 + Vite, React Router, MUI, Framer Motion
 - **Backend:** Convex (feedback, analytics events, site stats)
 - **Player data:** static `public/players.json`, refreshed daily by
   `.github/workflows/sync-players.yml` from the [nba2kapi](https://github.com/woverfield/nba2kapi)
@@ -39,7 +39,7 @@ Feb 2026 baseline was 6,210 teams / 3,105 drafts completed — steady growth.
 - **Funnel polish** — `draft_abandoned` (967) vs completed (3,315): investigate
   where the ~25% who start but don't finish drop off
 - **Roster freshness banner** — show "data as of <date>" from players.json
-- **PWA / install** — it's already a single-purpose tool people reopen
+- **Finish PWA / installability** — a `public/manifest.json` already exists; add a service worker so it's truly installable (single-purpose tool people reopen)
 
 ## Design principles
 1. Basketball-first, playground energy


### PR DESCRIPTION
The old ROADMAP described a **Next.js 14 + Supabase** rewrite that was never built. The app actually runs on **Vite + React + MUI + Convex**.

Rewrites it to reflect:
- Actual architecture and data-sync pipeline
- Current Convex prod usage (6,862 teams generated, 3,315 drafts completed)
- Health notes (player freshness depends on nba2kapi upstream; dev vs prod Convex deployment)
- Grounded, uncommitted next steps (shareable drafts, funnel polish, roster-freshness banner)

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)