### PR TITLE
fix: fit Draft as a diagonal versus lineup

### DIFF
--- a/docs/artifacts/007-gate-report.md
+++ b/docs/artifacts/007-gate-report.md
@@ -11,22 +11,24 @@
 
 | Gate | Verdict | Findings |
 |---|---|---|
-| Taste linter | PASS | Uses spatial composition and uniform scaling only; card design, type, colors, team ownership, and interaction law unchanged. Amendment 7 records wide labels-above composition. |
-| Adversarial review | PASS | Mobile <768px retains scrolling/full-size controls. Header/actions never scale. Keyboard row attributes and DOM order remain Player 1 → Player 2 → actions. |
-| Visual/interaction review | PASS after 1 fix | First pass: no vertical overflow, but 10px horizontal clip per side from unsupported calculated zoom. Fixed with explicit width breakpoints. Final 1280×720 geometry clean; both actions visible; selection and flip exercised. |
-
-## Geometry proof — 1280×720
-
-- Document: `scrollHeight=720`, `clientHeight=720`, no vertical overflow.
-- Matchup board: x `81.03–1198.97`, width `1117.94`, fully inside viewport.
-- REROLL bottom `533.15`; DONE bottom `536.15`; both visible.
-- Six selectable cards found; opposing picks selected; DONE enabled; STATS
-  control exercised.
+| Taste linter | PASS | Rejected six-card strip replaced by intentional diagonal versus composition. Player ownership is spatially distinct; court space is occupied without decorative filler. Existing card/tier/team laws unchanged. |
+| Adversarial review | PASS | Mobile <768px retains scrolling/full-size controls. Compact mode progressively removes PHYS, back extras, then TOP only on very short non-phone screens. Keyboard/interaction DOM order unchanged. |
+| Visual/interaction review | PASS after 1 fix | Initial diagonal pass exposed 2px back-face overflow at 250px density; category padding tightened 1px per side. Re-gate clean on all twelve faces. |
 
 ## Ranked uncertainty
 
-1. The 768–1099px rules are mathematically bounded and code-reviewed but the
-   in-app browser exposed only its 1280×720 surface during this gate. Capture
-   a tablet/small-laptop baseline when explicit viewport emulation is healthy.
-2. Wide layouts trade the original labels-left composition for labels-above;
-   this is the intentional price of eliminating the vertical scroll loop.
+1. At <=800px high, compact fronts prioritize HEIGHT/TEAM over PHYS/TOP and
+   compact backs prioritize the six category bars over badge/origin extras.
+   This is intentional progressive disclosure, but it is the strongest density
+   tradeoff in the packet.
+2. Explicit viewport emulation remains unavailable; the live browser's
+   authoritative surface was 1280×720.
+
+## Final geometry — 1280×720
+
+- Document: `clientHeight=scrollHeight=720`; no vertical overflow.
+- Player 1: x `20–640`, y `111–391`.
+- Player 2: x `640–1260`, y `301–581`.
+- Actions: REROLL bottom `646`, DONE bottom `649`; both visible.
+- Six draft cards × two faces: each inner face `238px` client/scroll height;
+  zero overflow.

--- a/docs/artifacts/007-gate-report.md
+++ b/docs/artifacts/007-gate-report.md
@@ -1,0 +1,32 @@
+# Gate Report — Packet 007: draft viewport fit
+
+## Static wall
+
+| Check | Result |
+|---|---|
+| `npm run build` | PASS |
+| `git diff --check` | PASS |
+
+## Review lenses
+
+| Gate | Verdict | Findings |
+|---|---|---|
+| Taste linter | PASS | Uses spatial composition and uniform scaling only; card design, type, colors, team ownership, and interaction law unchanged. Amendment 7 records wide labels-above composition. |
+| Adversarial review | PASS | Mobile <768px retains scrolling/full-size controls. Header/actions never scale. Keyboard row attributes and DOM order remain Player 1 → Player 2 → actions. |
+| Visual/interaction review | PASS after 1 fix | First pass: no vertical overflow, but 10px horizontal clip per side from unsupported calculated zoom. Fixed with explicit width breakpoints. Final 1280×720 geometry clean; both actions visible; selection and flip exercised. |
+
+## Geometry proof — 1280×720
+
+- Document: `scrollHeight=720`, `clientHeight=720`, no vertical overflow.
+- Matchup board: x `81.03–1198.97`, width `1117.94`, fully inside viewport.
+- REROLL bottom `533.15`; DONE bottom `536.15`; both visible.
+- Six selectable cards found; opposing picks selected; DONE enabled; STATS
+  control exercised.
+
+## Ranked uncertainty
+
+1. The 768–1099px rules are mathematically bounded and code-reviewed but the
+   in-app browser exposed only its 1280×720 surface during this gate. Capture
+   a tablet/small-laptop baseline when explicit viewport emulation is healthy.
+2. Wide layouts trade the original labels-left composition for labels-above;
+   this is the intentional price of eliminating the vertical scroll loop.

--- a/docs/context/design-direction.md
+++ b/docs/context/design-direction.md
@@ -66,3 +66,9 @@ Amendments are numbered and appended at the bottom; they ENFORCE, not document.
    deep-ink text/ring is reserved for completed system state (`✓ FIXED`), not
    actions, selection, decoration, or rarity values. It must remain visually
    distinct from lavender feedback-type chips. (Ruled after packet 006.)
+7. **2026-07-11 — Draft uses the viewport before the scrollbar.** At wide
+   desktop widths, Player 1 and Player 2 option sets sit side-by-side with
+   labels above; the matchup board may scale uniformly to fit width/height
+   while the header and actions stay full-size. Phones keep readable cards and
+   may scroll. Card dimensions and interaction contracts remain unchanged.
+   (Packet 007.)

--- a/docs/context/design-direction.md
+++ b/docs/context/design-direction.md
@@ -67,8 +67,8 @@ Amendments are numbered and appended at the bottom; they ENFORCE, not document.
    actions, selection, decoration, or rarity values. It must remain visually
    distinct from lavender feedback-type chips. (Ruled after packet 006.)
 7. **2026-07-11 — Draft uses the viewport before the scrollbar.** At wide
-   desktop widths, Player 1 and Player 2 option sets sit side-by-side with
-   labels above; the matchup board may scale uniformly to fit width/height
-   while the header and actions stay full-size. Phones keep readable cards and
-   may scroll. Card dimensions and interaction contracts remain unchanged.
-   (Packet 007.)
+   desktop widths, Player 1 stages upper-left and Player 2 lower-right like a
+   versus lineup; labels sit above each three-card set. Short viewports use a
+   true compact draft density (smaller art, progressive secondary-detail
+   removal), never a uniformly shrunken six-card strip. Phones keep readable
+   cards and may scroll. Interaction contracts remain unchanged. (Packet 007.)

--- a/docs/work-packets/007-draft-viewport-fit.md
+++ b/docs/work-packets/007-draft-viewport-fit.md
@@ -1,0 +1,40 @@
+# Packet 007 — Draft viewport fit
+
+**Branch:** `fix/draft-viewport-fit`
+**Taste law:** `docs/context/design-direction.md` + amendments 1–6.
+**Protocol:** `docs/context/builder-protocol.md`.
+
+## Goal
+
+Keep the complete draft decision loop—round context, both option sets, and
+REROLL/NEXT—inside common desktop/laptop viewports without shrinking phone UI
+below readable touch size.
+
+## Contract
+
+1. At wide desktop widths (>=1100px), place Player 1 and Player 2 option sets
+   side-by-side, with team labels above their respective three-card rows.
+2. Scale the wide matchup board only enough to fit available width; keep the
+   header and primary actions full-size.
+3. On medium tablet/small-laptop widths, retain stacked rows with conservative
+   height-aware scaling.
+4. Below 768px, preserve the existing readable wrapping/vertical scroll.
+5. Do not change card dimensions, interactions, draft state, keyboard rows,
+   analytics, or data.
+6. On >=768px viewports, the draft shell owns `100dvh` and does not create a
+   vertical scrollbar when the fit rules apply.
+
+## Proof
+
+- `npm run build`; `git diff --check`.
+- Browser geometry checks for full control visibility and page overflow.
+- Pointer/keyboard selection and flip behavior unchanged.
+
+## Status log
+
+- 2026-07-11 — Built and browser-gated. At 1280×720 the first pass removed
+  vertical overflow but clipped the 1300px matchup board by 10px per side
+  because Chromium ignored calculated `zoom`; replaced with deterministic
+  width breakpoints. Re-gate: board 1117.94px wide at x=81.03–1198.97,
+  document scrollHeight=clientHeight=720, REROLL/DONE visible. Selection + flip
+  interaction check clean. Gate report: `docs/artifacts/007-gate-report.md`.

--- a/docs/work-packets/007-draft-viewport-fit.md
+++ b/docs/work-packets/007-draft-viewport-fit.md
@@ -12,15 +12,15 @@ below readable touch size.
 
 ## Contract
 
-1. At wide desktop widths (>=1100px), place Player 1 and Player 2 option sets
-   side-by-side, with team labels above their respective three-card rows.
-2. Scale the wide matchup board only enough to fit available width; keep the
-   header and primary actions full-size.
-3. On medium tablet/small-laptop widths, retain stacked rows with conservative
-   height-aware scaling.
+1. At wide desktop widths, stage Player 1 upper-left and Player 2 lower-right,
+   with labels above their respective three-card rows.
+2. On short desktop/tablet heights, use a true compact card density: smaller
+   art and progressive secondary-detail removal, never uniform zoom.
+3. On medium tablet/small-laptop widths, retain stacked rows with the same
+   height-aware compact density.
 4. Below 768px, preserve the existing readable wrapping/vertical scroll.
-5. Do not change card dimensions, interactions, draft state, keyboard rows,
-   analytics, or data.
+5. Do not change card interactions, draft state, keyboard rows, analytics, or
+   data. Compact dimensions are responsive presentation only.
 6. On >=768px viewports, the draft shell owns `100dvh` and does not create a
    vertical scrollbar when the fit rules apply.
 
@@ -32,9 +32,9 @@ below readable touch size.
 
 ## Status log
 
-- 2026-07-11 — Built and browser-gated. At 1280×720 the first pass removed
-  vertical overflow but clipped the 1300px matchup board by 10px per side
-  because Chromium ignored calculated `zoom`; replaced with deterministic
-  width breakpoints. Re-gate: board 1117.94px wide at x=81.03–1198.97,
-  document scrollHeight=clientHeight=720, REROLL/DONE visible. Selection + flip
-  interaction check clean. Gate report: `docs/artifacts/007-gate-report.md`.
+- 2026-07-11 — Initial horizontal six-card strip passed geometry but failed
+  Wilson's taste pass: flattened player ownership and left a dead lower court.
+  Redirected to a diagonal versus composition with responsive compact card
+  density. At 1280×720, P1 occupies x=20–640/y=111–391 and P2 occupies
+  x=640–1260/y=301–581; actions end at y=649; no document or card-face
+  overflow. Final gate evidence: `docs/artifacts/007-gate-report.md`.

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -71,11 +71,13 @@ function CardBody({
   }, [flipped]);
 
   const tier = tierFor(player.overall);
-  const height = density === "draft" ? 344 : 404;
+  const height = density === "draft" ? "var(--bb-draft-card-height, 344px)" : 404;
 
   return (
     <div
-      className={selected ? "bb-notch bb-notch-selected" : "bb-notch bb-ring-ink"}
+      className={`${density === "draft" ? "bb-card-draft " : ""}${
+        selected ? "bb-notch bb-notch-selected" : "bb-notch bb-ring-ink"
+      }`}
       style={{
         width: 196,
         height,
@@ -157,7 +159,7 @@ function CardFace({
         {side === "front" ? (
           <FrontContent player={player} density={density} tier={tier} />
         ) : (
-          <BackContent player={player} />
+          <BackContent player={player} density={density} />
         )}
         <button
           type="button"
@@ -208,7 +210,7 @@ function CardHeader({ player, tier, selected }) {
 function FrontContent({ player, density, tier }) {
   return (
     <>
-      <ArtWindow player={player} />
+      <ArtWindow player={player} density={density} />
       <div className="flex gap-1.5 px-2 pt-2 shrink-0">
         <span className="bb-chip-filled text-[7px] px-1.5 py-1">
           {ERA_LABELS[player.type] || player.type}
@@ -221,14 +223,16 @@ function FrontContent({ player, density, tier }) {
       </div>
       <div className="px-2 pt-1">
         <StatRow label="HEIGHT" value={player.height || "—"} />
-        <StatRow
-          label="PHYS"
-          value={
-            [player.weight, player.wingspan ? `${player.wingspan} WS` : null]
-              .filter(Boolean)
-              .join(" · ") || "—"
-          }
-        />
+        <div className="bb-draft-phys">
+          <StatRow
+            label="PHYS"
+            value={
+              [player.weight, player.wingspan ? `${player.wingspan} WS` : null]
+                .filter(Boolean)
+                .join(" · ") || "—"
+            }
+          />
+        </div>
         <StatRow label="TEAM" value={player.team} />
         {density === "reveal" && (
           <>
@@ -259,11 +263,12 @@ function FrontContent({ player, density, tier }) {
   );
 }
 
-function ArtWindow({ player }) {
+function ArtWindow({ player, density }) {
   return (
     <div
-      className="relative overflow-hidden shrink-0 bg-cardart"
-      style={{ height: 100 }}
+      className={`bb-card-art relative overflow-hidden shrink-0 bg-cardart${
+        density === "draft" ? " bb-card-art-draft" : ""
+      }`}
     >
       {player.playerImg ? (
         // referrerPolicy="no-referrer" defeats 2kratings.com hot-link 403s
@@ -333,7 +338,7 @@ function StatRow({ label, value, valueColor }) {
 function TopSkills({ player, compact = false }) {
   if (compact) {
     return (
-      <div className="px-2 pt-[5px] flex items-center gap-[6px]">
+      <div className="bb-draft-top px-2 pt-[5px] flex items-center gap-[6px]">
         <span className="font-vt text-[14px] text-muted leading-none shrink-0">
           TOP
         </span>
@@ -375,7 +380,7 @@ function SkillChips({ player, compact = false }) {
   );
 }
 
-function BackContent({ player }) {
+function BackContent({ player, density }) {
   const attrs = attrsFor(player);
   return (
     <>
@@ -388,7 +393,7 @@ function BackContent({ player }) {
         {ATTR_KEYS.map((key) => (
           <div
             key={key}
-            className="flex items-center justify-between gap-1 py-[4px]"
+            className="bb-attribute-row flex items-center justify-between gap-1 py-[4px]"
           >
             <span className="font-vt text-[15px] text-muted leading-none w-[26px] shrink-0">
               {ATTR_ABBREVS[key]}
@@ -410,7 +415,7 @@ function BackContent({ player }) {
           * placeholder values pending attribute data
         </p>
       )}
-      <div className="px-2 pt-1 mt-auto">
+      <div className={`${density === "draft" ? "bb-card-back-extra " : ""}px-2 pt-1 mt-auto`}>
         <StatRow
           label="BADGES"
           value={

--- a/src/components/PlayerOptions.jsx
+++ b/src/components/PlayerOptions.jsx
@@ -127,10 +127,10 @@ export default function PlayerOptions({ pool, size, onDone, onAbandon }) {
   useKeyboardNav({ onEscape: handleAbandon });
 
   return (
-    <div className="relative w-full">
+    <div className="bb-draft-shell relative w-full">
       <div className="bb-scrim-draft z-0 pointer-events-none" />
       <EscHint label="EXIT" />
-      <div className="relative z-10 flex flex-col items-center px-4 pt-6 pb-14">
+      <div className="bb-draft-stage relative z-10 flex flex-col items-center px-4 pt-6 pb-14">
         {/* Header: spacer · ROUND n · X */}
         <header className="w-full max-w-[1100px] flex items-start justify-between gap-4">
           <div className="w-[43px] shrink-0" />
@@ -157,28 +157,30 @@ export default function PlayerOptions({ pool, size, onDone, onAbandon }) {
           </button>
         </header>
 
-        <DraftRow
-          label="PLAYER 1 PICKS"
-          colorClass="text-teamblue"
-          options={opts1}
-          selected={sel1}
-          onSelect={(i) => setSel1(sel1 === i ? null : i)}
-          rollId={rollId}
-          rowKey="p1"
-          navCardRow="10"
-          navTabRow="11"
-        />
-        <DraftRow
-          label="PLAYER 2 PICKS"
-          colorClass="text-teamcoral"
-          options={opts2}
-          selected={sel2}
-          onSelect={(i) => setSel2(sel2 === i ? null : i)}
-          rollId={rollId}
-          rowKey="p2"
-          navCardRow="20"
-          navTabRow="21"
-        />
+        <div className="bb-draft-picks">
+          <DraftRow
+            label="PLAYER 1 PICKS"
+            colorClass="text-teamblue"
+            options={opts1}
+            selected={sel1}
+            onSelect={(i) => setSel1(sel1 === i ? null : i)}
+            rollId={rollId}
+            rowKey="p1"
+            navCardRow="10"
+            navTabRow="11"
+          />
+          <DraftRow
+            label="PLAYER 2 PICKS"
+            colorClass="text-teamcoral"
+            options={opts2}
+            selected={sel2}
+            onSelect={(i) => setSel2(sel2 === i ? null : i)}
+            rollId={rollId}
+            rowKey="p2"
+            navCardRow="20"
+            navTabRow="21"
+          />
+        </div>
 
         <div className="flex items-center justify-center gap-[20px] mt-10">
           <button
@@ -216,7 +218,7 @@ function DraftRow({
   navTabRow,
 }) {
   return (
-    <section className="w-full max-w-[1100px] flex items-center justify-center gap-6 flex-wrap mt-10">
+    <section className="bb-draft-row w-full max-w-[1100px] flex items-center justify-center gap-6 flex-wrap mt-10">
       <h2
         className={`font-press text-[12px] ${colorClass} bb-outline-2 w-[110px] shrink-0 leading-[18px]`}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -286,6 +286,10 @@ body {
   align-items: center;
 }
 
+.bb-card-art {
+  height: 100px;
+}
+
 @media (min-width: 768px) {
   .bb-draft-shell {
     height: 100dvh;
@@ -297,51 +301,94 @@ body {
   }
 }
 
-/* Small laptops/tablets: retain the familiar stack, but fit the full loop. */
-@media (min-width: 768px) and (max-width: 1099px) {
-  .bb-draft-picks {
-    zoom: 0.78;
-  }
-
+/* Short non-phone viewports use a true compact card density, never zoom. */
+@media (min-width: 768px) and (max-height: 1050px) {
   .bb-draft-stage {
     padding-top: 16px;
-    padding-bottom: 20px;
-  }
-
-  .bb-draft-stage > header + .bb-draft-picks {
-    margin-top: -8px;
-  }
-
-  .bb-draft-stage > .bb-draft-picks + div {
-    margin-top: 16px;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1099px) and (max-height: 820px) {
-  .bb-draft-picks {
-    zoom: 0.68;
-  }
-}
-
-/* Wide screens use one matchup board instead of two tall rows. */
-@media (min-width: 1100px) {
-  .bb-draft-picks {
-    width: max-content;
-    max-width: none;
-    flex-direction: row;
-    justify-content: center;
-    align-items: flex-start;
-    gap: 28px;
-    margin-top: 28px;
-    zoom: 0.78;
+    padding-bottom: 16px;
   }
 
   .bb-draft-row {
-    width: auto;
+    margin-top: 20px;
+  }
+
+  .bb-draft-stage > .bb-draft-picks + div {
+    margin-top: 20px;
+  }
+
+  .bb-card-draft {
+    --bb-draft-card-height: 280px;
+  }
+
+  .bb-card-draft .bb-card-art-draft {
+    height: 70px;
+  }
+
+  .bb-card-draft .bb-draft-phys,
+  .bb-card-draft .bb-card-back-extra {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) and (max-height: 800px) {
+  .bb-draft-stage {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  .bb-draft-row {
+    margin-top: 12px;
+  }
+
+  .bb-draft-stage > .bb-draft-picks + div {
+    margin-top: 12px;
+  }
+
+  .bb-card-draft {
+    --bb-draft-card-height: 250px;
+  }
+
+  .bb-card-draft .bb-card-art-draft {
+    height: 60px;
+  }
+
+  .bb-card-draft .bb-draft-top {
+    display: none;
+  }
+
+  .bb-card-draft .bb-attribute-row {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}
+
+/* Wide screens stage the two lineups diagonally like a versus reveal. */
+@media (min-width: 1272px) {
+  .bb-draft-picks {
+    position: relative;
+    width: calc(100% - 8px);
+    max-width: 1240px;
+    height: 650px;
+    margin-top: 18px;
+  }
+
+  .bb-draft-row {
+    position: absolute;
+    width: 620px;
     margin-top: 0;
     flex-direction: column;
     flex-wrap: nowrap;
-    gap: 16px;
+    gap: 12px;
+  }
+
+  .bb-draft-row:first-child {
+    top: 0;
+    left: 0;
+  }
+
+  .bb-draft-row:last-child {
+    right: 0;
+    bottom: 0;
   }
 
   .bb-draft-row > h2 {
@@ -351,22 +398,23 @@ body {
 
   .bb-draft-row > div {
     flex-wrap: nowrap;
+    gap: 16px;
   }
 
   .bb-draft-stage > .bb-draft-picks + div {
-    margin-top: 24px;
+    margin-top: 12px;
   }
 }
 
-@media (min-width: 1200px) and (max-width: 1399px) {
+@media (min-width: 1272px) and (max-height: 1050px) {
   .bb-draft-picks {
-    zoom: 0.86;
+    height: 520px;
   }
 }
 
-@media (min-width: 1400px) {
+@media (min-width: 1272px) and (max-height: 800px) {
   .bb-draft-picks {
-    zoom: 1;
+    height: 470px;
   }
 }
 .bb-scrim-versus {

--- a/src/index.css
+++ b/src/index.css
@@ -277,6 +277,98 @@ body {
   inset: 0;
   background: rgba(23, 13, 42, 0.7);
 }
+
+/* Draft viewport fit (packet 007). Mobile keeps full-size cards + scrolling. */
+.bb-draft-picks {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+@media (min-width: 768px) {
+  .bb-draft-shell {
+    height: 100dvh;
+    overflow: hidden;
+  }
+
+  .bb-draft-stage {
+    min-height: 100dvh;
+  }
+}
+
+/* Small laptops/tablets: retain the familiar stack, but fit the full loop. */
+@media (min-width: 768px) and (max-width: 1099px) {
+  .bb-draft-picks {
+    zoom: 0.78;
+  }
+
+  .bb-draft-stage {
+    padding-top: 16px;
+    padding-bottom: 20px;
+  }
+
+  .bb-draft-stage > header + .bb-draft-picks {
+    margin-top: -8px;
+  }
+
+  .bb-draft-stage > .bb-draft-picks + div {
+    margin-top: 16px;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1099px) and (max-height: 820px) {
+  .bb-draft-picks {
+    zoom: 0.68;
+  }
+}
+
+/* Wide screens use one matchup board instead of two tall rows. */
+@media (min-width: 1100px) {
+  .bb-draft-picks {
+    width: max-content;
+    max-width: none;
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 28px;
+    margin-top: 28px;
+    zoom: 0.78;
+  }
+
+  .bb-draft-row {
+    width: auto;
+    margin-top: 0;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    gap: 16px;
+  }
+
+  .bb-draft-row > h2 {
+    width: auto;
+    text-align: center;
+  }
+
+  .bb-draft-row > div {
+    flex-wrap: nowrap;
+  }
+
+  .bb-draft-stage > .bb-draft-picks + div {
+    margin-top: 24px;
+  }
+}
+
+@media (min-width: 1200px) and (max-width: 1399px) {
+  .bb-draft-picks {
+    zoom: 0.86;
+  }
+}
+
+@media (min-width: 1400px) {
+  .bb-draft-picks {
+    zoom: 1;
+  }
+}
 .bb-scrim-versus {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## What changed
- Player 1 stages upper-left and Player 2 lower-right like a versus lineup
- preserves two distinct three-card teams instead of flattening all six cards
- short desktop/tablet views use true compact card density, not uniform zoom
- secondary detail progressively hides only when height demands it
- phones retain full-size readable cards and scrolling

## Proof
- npm run build
- git diff --check
- 1280x720 browser gate: document clientHeight=scrollHeight=720
- P1 x=20–640/y=111–391; P2 x=640–1260/y=301–581
- REROLL/DONE visible, ending at y=649
- all six cards, both faces: exact 238px client/scroll parity; no internal overflow
- gate report: docs/artifacts/007-gate-report.md

## Taste redirect
The initial horizontal six-card strip passed geometry but was rejected because it flattened player ownership and left the lower court dead. This version follows Wilson’s diagonal lineup/versus direction.