### PR TITLE
Refresh project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,85 @@
 # Blacktop Blitz
 
-Blacktop Blitz is a React application designed to help NBA 2K players quickly generate and draft teams for the Blacktop game mode. Whether you're playing solo or with friends, Blacktop Blitz makes team creation fun, fast, and efficient.
+An NBA 2K Blacktop team randomizer for quickly drafting balanced—or deliberately chaotic—matchups with friends.
 
-Site: https://blacktopblitz.com/
+**[Play Blacktop Blitz](https://blacktopblitz.com/)**
+
+![Blacktop Blitz home screen](https://github.com/user-attachments/assets/3c532960-4832-4b0f-b6d2-4a2d514f58fa)
 
 ## Features
 
-- **Random Team Generation:** Generate random teams based on selected criteria.
-- **Player Database:** Utilizes Web-Scraped NBA2k player data for accurate ratings and players.
-- **Responsive Design:** Works seamlessly on desktop and mobile devices.
+- Draft teams from current, classic, and all-time NBA 2K rosters
+- Set matchup sizes from 1v1 through 5v5
+- Filter the player pool by overall rating, position, height, team, and pre-NBA experience
+- Add minimum thresholds for individual attributes, category ratings, badges, and wingspan
+- Open a player's complete ratings profile directly from the draft
+- Navigate the full experience with a keyboard or pointer on desktop and mobile
+- Automatically switch between day and night visual themes
+
+## Running locally
+
+Blacktop Blitz requires a current version of [Node.js](https://nodejs.org/) and npm.
+
+```bash
+git clone https://github.com/wkoverfield/blacktop-blitz.git
+cd blacktop-blitz
+npm install
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173) in your browser.
 
 ## Scripts
 
-## Player Data
+| Command | Purpose |
+| --- | --- |
+| `npm run dev` | Start the Vite development server |
+| `npm run build` | Create a production build in `dist/` |
+| `npm run preview` | Preview the production build locally |
 
-Player data lives in `public/players.json` and is refreshed automatically once a day by `.github/workflows/sync-players.yml`, which pulls from the [nba2kapi](https://github.com/wkoverfield/nba2kapi) `/api/players/bulk` endpoint. The frontend loads it as a same-origin static file — no API calls from end-user browsers.
+## Tech stack
 
-**Force a manual sync:**
+- React 18 and React Router
+- Vite
+- Tailwind CSS
+- Convex
+- Framer Motion
+- Vercel Analytics and Speed Insights
+
+## Player data
+
+Player data lives in `public/players.json`. A scheduled GitHub Actions workflow refreshes it daily from the [nba2kapi](https://github.com/wkoverfield/nba2kapi) bulk players endpoint. The frontend serves the roster as a same-origin static asset, so end-user browsers do not call the API directly.
+
+To trigger a refresh manually:
+
 ```bash
-# from the Actions tab, or via CLI:
 gh workflow run sync-players.yml
 ```
 
-**Run the sync locally (rare — only needed if iterating on the sync script):**
+To run the sync script locally while working on the data pipeline:
+
 ```bash
 NBA2KAPI_KEY="2k_..." node scripts/sync-players.mjs
 ```
 
-## Installation
-
-To run Blacktop Blitz locally, follow these steps:
-
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/wkoverfield/blacktop-blitz.git
-   ```
-
-2. Navigate into the project directory:
-
-   ```bash
-   cd blacktop-blitz
-   ```
-
-3. Install dependencies:
-
-   ```bash
-   npm install
-   ```
-
-4. Start the application:
-
-   ```bash
-   npm start
-   ```
-
-5. Open your browser and visit `http://localhost:3000` to view Blacktop Blitz.
-
-- NBA 2K for inspiring the Blacktop game mode.
-- React and its vibrant community for providing excellent tools and libraries.
+Do not edit `public/players.json` by hand; the next scheduled sync will replace it.
 
 ## Analytics
 
-Usage tracking added February 2026. Events tracked: query filters, draft starts, player selections, completions, and abandonments.
+Blacktop Blitz launched in July 2024. Estimated cumulative growth:
 
-**Baseline (Feb 2025 - Feb 2026):** ~3,100 unique visitors, ~5,500 drafts started.
+| Snapshot | Visitors | Drafts started |
+| --- | ---: | ---: |
+| July 2025 | ~2,978 | — |
+| February 2026 | ~5,200 | ~5,500 |
+| July 2026 | 7,017 | ~8,700 |
+
+Year two brought 4,348 visitors, up 46% from year one.
 
 ## Screenshots
-![image](https://github.com/user-attachments/assets/3c532960-4832-4b0f-b6d2-4a2d514f58fa)
 
-![image](https://github.com/user-attachments/assets/2ba5a489-f881-4629-9ec5-9eb2af110dde)
+![Blacktop Blitz team draft](https://github.com/user-attachments/assets/2ba5a489-f881-4629-9ec5-9eb2af110dde)
 
+## Credits
+
+Blacktop Blitz was inspired by NBA 2K's Blacktop mode and the now-retired 2K Blacktop Randomizer. Player ratings and roster data are sourced through [nba2kapi](https://nba2kapi.com), which tracks data published by [2K Ratings](https://www.2kratings.com/).


### PR DESCRIPTION
## What changed
- rewrote the README around the shipped Blacktop Blitz experience
- corrected local Vite setup, scripts, stack, and player-data documentation
- added a simple cumulative visitors and drafts scoreboard using the recovered 24-month analytics
- refreshed screenshots and attribution

## Why
The previous README still described the older app setup and no longer reflected the product, data pipeline, or two years of growth.

## Validation
- `git diff --check`
- verified commands and features against `package.json` and the current source
- verified visitor totals against Vercel's 12- and 24-month analytics
