### PR TITLE
Bank permanent daily metric snapshots

### DIFF
--- a/src/convex/_generated/api.d.ts
+++ b/src/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as analytics from "../analytics.js";
 import type * as crons from "../crons.js";
 import type * as feedback from "../feedback.js";
+import type * as metricsRollup from "../metricsRollup.js";
 import type * as qaCleanup from "../qaCleanup.js";
 import type * as siteStats from "../siteStats.js";
 
@@ -24,6 +25,7 @@ declare const fullApi: ApiFromModules<{
   analytics: typeof analytics;
   crons: typeof crons;
   feedback: typeof feedback;
+  metricsRollup: typeof metricsRollup;
   qaCleanup: typeof qaCleanup;
   siteStats: typeof siteStats;
 }>;

--- a/src/convex/crons.ts
+++ b/src/convex/crons.ts
@@ -16,4 +16,10 @@ crons.daily(
   internal.siteStats.pruneVisits
 );
 
+crons.daily(
+  "daily metric snapshot",
+  { hourUTC: 8, minuteUTC: 10 },
+  internal.metricsRollup.snapshotDailyMetrics
+);
+
 export default crons;

--- a/src/convex/metricsRollup.ts
+++ b/src/convex/metricsRollup.ts
@@ -1,0 +1,62 @@
+import { internalMutation, query } from "./_generated/server";
+
+const dstr = (ms: number) => new Date(ms).toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+
+/**
+ * Bank a permanent daily snapshot of every cumulative usage counter.
+ *
+ * analyticsAggregates and pageviewCounters never prune, but each holds only a
+ * single running total: the day-by-day history is not recoverable from them,
+ * and raw analyticsEvents are pruned at 90 days. Recording the running totals
+ * once per UTC day makes any window (7d / 30d / yearly) derivable forever from
+ * consecutive snapshots. The delta between two days' snapshots is that day's
+ * real activity, which also cancels the backfilled floor baked into the
+ * lifetime aggregates, so going-forward per-day numbers stay correct.
+ *
+ * Idempotent: exactly one row per UTC date. A second run on the same day
+ * patches the existing row instead of inserting a duplicate.
+ */
+export const snapshotDailyMetrics = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const date = dstr(now);
+
+    const metrics: Record<string, number> = {};
+
+    // Cumulative lifetime action counts (survive the 90-day event prune).
+    const aggs = await ctx.db.query("analyticsAggregates").collect();
+    for (const a of aggs) metrics[`action:${a.eventType}`] = a.count;
+
+    // Pageview counters: cumulative total plus this UTC day's running tallies.
+    const counters = await ctx.db.query("pageviewCounters").collect();
+    const byKey: Record<string, number> = {};
+    for (const c of counters) byKey[c.key] = c.count;
+    metrics["pageviews_total"] = byKey["total"] ?? 0;
+    metrics["pageviews_today"] = byKey[`day:${date}`] ?? 0;
+    metrics["uniques_today"] = byKey[`uvday:${date}`] ?? 0;
+
+    const existing = await ctx.db
+      .query("metricSnapshots")
+      .withIndex("by_date", (q) => q.eq("date", date))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { capturedAt: now, metrics });
+    } else {
+      await ctx.db.insert("metricSnapshots", { date, capturedAt: now, metrics });
+    }
+
+    return { date, metricKeys: Object.keys(metrics).length };
+  },
+});
+
+/**
+ * Return the full snapshot series ordered by date (oldest first).
+ */
+export const getMetricSnapshots = query({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("metricSnapshots").withIndex("by_date").collect();
+    return rows.map((r) => ({ date: r.date, capturedAt: r.capturedAt, metrics: r.metrics }));
+  },
+});

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -47,4 +47,14 @@ export default defineSchema({
     date: v.string(),
     visitorId: v.string(),
   }).index("by_date_and_visitor", ["date", "visitorId"]),
+
+  // Permanent daily snapshot of every cumulative usage counter. The source
+  // aggregates never hold day-by-day history, and raw analyticsEvents prune at
+  // 90 days; banking the running totals once per UTC day makes any window
+  // (7d / 30d / yearly) derivable forever from consecutive snapshots.
+  metricSnapshots: defineTable({
+    date: v.string(), // UTC "YYYY-MM-DD"
+    capturedAt: v.number(),
+    metrics: v.record(v.string(), v.number()),
+  }).index("by_date", ["date"]),
 });


### PR DESCRIPTION
## What

Adds a `metricSnapshots` table and a daily cron (`snapshotDailyMetrics`, 08:10 UTC) that records every cumulative usage counter once per UTC day, plus a `getMetricSnapshots` query that returns the series ordered by date.

## Why

`analyticsAggregates` and `pageviewCounters` never prune, but each holds only a single running total. The day-by-day history is not recoverable from them, and raw `analyticsEvents` are pruned at 90 days by the existing cleanup cron. That makes any window longer than 90 days (30d rolling past the boundary, yearly) impossible to derive once events age out.

Banking the running totals once per UTC day makes any window (7d / 30d / yearly) derivable forever from consecutive snapshots. The delta between two days' snapshots is that day's real activity, which also cancels the backfilled floor baked into the lifetime aggregates, so going-forward per-day numbers stay correct.

## Snapshot shape

One row per UTC date: `{ date, capturedAt, metrics }` where `metrics` is a `record<string, number>`. Keys captured:

- `action:<eventType>` per `analyticsAggregates` row (cumulative lifetime action counts)
- `pageviews_total` (cumulative), `pageviews_today`, `uniques_today` (this UTC day's running tallies)

The upsert is keyed by UTC date, so a rerun on the same day patches the existing row rather than inserting a duplicate.

## Scope

Additive and backend-only. No client, game logic, or existing cron touched. Codegen committed.

## Verification (dev deployment)

- `npx convex dev --once`: pushed clean, `metricSnapshots.by_date` index added, functions typecheck.
- `npm run build`: passes.
- Ran `snapshotDailyMetrics` twice: one row for the UTC date both times (same `_id` / `_creationTime`, only `capturedAt` patched) confirming idempotency.
- `getMetricSnapshots` returns the series with all metric keys.