### PR TITLE
Front-load team generator terms in title, description, and JSON-LD

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/x-icon" sizes="16x16 32x32 48x48" href="/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#241436" />
-  <meta name="description" content="Free NBA 2K team randomizer for Blacktop mode. Generate random teams from current players, all-time legends, and classic rosters. The best 2K blacktop randomizer online." />
+  <meta name="description" content="Random NBA 2K team generator for Blacktop mode. Draft random teams from current players, classic rosters, and all-time legends, free in your browser. The 2K blacktop randomizer." />
   <meta name="keywords" content="NBA 2K randomizer, 2K blacktop randomizer, NBA 2K team generator, blacktop blitz, 2K random teams, NBA 2K25 randomizer, NBA 2K blacktop, random team generator" />
   <meta name="author" content="Wilson Overfield" />
   <meta name="google-site-verification" content="Y7hqlN0W6dInxcEIzad8oAMgsi8WvZXzT9pIzhu4TDA" />
@@ -41,7 +41,24 @@
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Pixelify+Sans:wght@400..700&family=VT323&display=swap">
   <link rel="preload" fetchpriority="high" as="fetch" href="/players.json" crossorigin>
-  <title>Blacktop Blitz - NBA 2K Team Randomizer | 2K Blacktop Random Team Generator</title>
+  <title>Blacktop Blitz: Random NBA 2K Team Generator and Blacktop Randomizer</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Blacktop Blitz",
+    "alternateName": "2K Blacktop Random Team Generator",
+    "url": "https://blacktopblitz.com/",
+    "description": "Random NBA 2K team generator for Blacktop mode. Draft random teams from current players, classic rosters, and all-time legends, free in your browser.",
+    "applicationCategory": "GameApplication",
+    "operatingSystem": "Web browser",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    }
+  }
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
Search Console shows exact-intent queries ("2k team generator", "random 2k team generator", "blacktop 2k", ~600 impressions over 3 months) ranking positions 6-8 with near-zero clicks. The title contained the right words but the highest-intent phrase fell past the ~60-character display truncation, and there was no structured data.

- Title: "Blacktop Blitz: Random NBA 2K Team Generator and Blacktop Randomizer" (brand first; "blacktop blitz" holds position 1 at 80% CTR and is unaffected)
- Description now leads with the query phrasing
- WebApplication JSON-LD with the generator alternateName

Metadata only: no visible page, component, or copy changes. Production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)